### PR TITLE
Huge Update (V3.0 ?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 
 # Requirements
 
-- Python 3.6+
+- Python 3.6.X
 - Discord
-- Pip
-- Android emulator / device running android 6 or below, or an iOS device
+- Pip (included with Python 3.6.X)
+- Android Emulator (Nox) / Device running Android 5 or 6, or an iOS device
 
 (If using iOS, I recommend using ikaWidget2 instead of the official NSO app, as you can pull to refresh to quickly get the cookie)
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 3. Run setup.py - we do make some installations using pip here, so if pip needs root/admin access for you, run this as such
 4. Run discord_rich_presence.py - you should be prompted to how to login once running this, and you should be up and running in no time!
 
+Video Tutorial Coming Soon!
+
 # FAQs
 
 ## How do I change the friend code?

--- a/discord_rich_presence.py
+++ b/discord_rich_presence.py
@@ -23,13 +23,23 @@ show_weapon = True  # change to False to remove weapon name from discord details
 
 
 def get_minutes_since():
+    
     matches = nso.load_results()
-    try:
-        match_end = int(matches[0]["start_time"] + matches[0][
-            "elapsed_time"])  # adds the seconds of the match to the unix time of the match starting
-    except KeyError:
-        match_end = int(matches[0][
-            "start_time"] + 180)  # we assume that the match lasted 3 minutes here, as sometimes the API doesn't give us how long the match took
+
+    # When Previous Match was Salmon Run
+    if matches[0].get('job_result') is not None:
+        match_end = int(
+            matches[0]["play_time"])
+
+    # When Previous Match was Turf, Ranked, League or Private
+    else:
+        try:
+            match_end = int(matches[0]["start_time"] + matches[0][
+                "elapsed_time"])  # adds the seconds of the match to the unix time of the match starting
+        except KeyError:
+            match_end = int(matches[0][
+                "start_time"] + 180)  # we assume that the match lasted 3 minutes here, as sometimes the API doesn't give us how long the match took
+
     match_end_time = timedelta(0, match_end)
     match_time_diff = datetime.utcnow()
     time_to_last_match = match_time_diff - match_end_time
@@ -60,12 +70,10 @@ def main():
         exit(1)
 
     # Load our current config
-
     config = nso_functions.get_config_file()
-
     logger.info("Check discord!")
 
-    # get friend code from config, and add config option if does not exist
+    # Get friend code from config, and add config option if does not exist
     try:
         friend_code = config['friend_code']
     except KeyError:
@@ -77,74 +85,210 @@ def main():
 
     while True:  # The presence will stay on as long as the program is running
 
-        for i in range(0, 4):
+        for i in range(0, 5):
             minutes_since, last_match = get_minutes_since()
+
             # int is here so we don't have funky floating point madness
             seconds_since = int(minutes_since * 60)
             hours_since = int(minutes_since / 60)
-            if minutes_since >= 60:
-                details = "Last match: {} hour(s) ago".format(hours_since)
-            elif minutes_since > 1:
-                details = "Last match: {} minute(s) ago".format(
-                    math.floor(minutes_since))
-            else:
-                details = "Last match: {} second(s) ago".format(seconds_since)
+            
+            # When Previous Match was Salmon Run
             # job_result is only present in salmon run JSON
             if last_match.get('job_result') is not None:
+
+                # Sets Gamemode Key in order to change the Picture
                 gamemode_key = "salmon_run"
-                if last_match['job_result']['is_clear']:
-                    outcome = "winning"
+
+                # Decides if last Run is shown in hours, minutes or seconds
+                if minutes_since >= 60:
+                    details = "Last Run: {} h(s) ago".format(hours_since)
+                elif minutes_since > 1:
+                    details = "Last Run: {} min(s) ago".format(
+                        math.floor(minutes_since)
+                    )
                 else:
-                    outcome = "losing"
-                large_text = "Last match was Salmon Run, {} with {} eggs".format(
-                    outcome, last_match['job_score'])
+                    details = "Last Run: {} sec(s) ago".format(
+                        seconds_since
+                    )
+
+                # Deciding the Result
+                if last_match['job_result']['is_clear']:
+                    outcome = "WON"
+                else:
+                    outcome = "LOST"
+
+                ### Checks how many waves were played on last Run
+                # If all 3 Waves were played
+                if last_match["wave_details"][2]:
+                    goldEgg = last_match["wave_details"][0]["golden_ikura_num"] + \
+                        last_match["wave_details"][1]["golden_ikura_num"] + \
+                        last_match["wave_details"][2]["golden_ikura_num"]
+                    powEgg = last_match["wave_details"][0]["ikura_num"] + \
+                        last_match["wave_details"][1]["ikura_num"] + \
+                        last_match["wave_details"][2]["ikura_num"]
+
+                # If only 2 Waves were played
+                elif not last_match["wave_details"][2] and last_match["wave_details"][1]:
+                    goldEgg = last_match["wave_details"][0]["golden_ikura_num"] + last_match["wave_details"][1]["golden_ikura_num"]
+                    powEgg = last_match["wave_details"][0]["ikura_num"] + last_match["wave_details"][1]["ikura_num"]
+
+                # If only 1 Wave was played
+                else:
+                    goldEgg = last_match["wave_details"][0]["golden_ikura_num"]
+                    powEgg = last_match["wave_details"][0]["ikura_num"]
+
+                # When hovering on the Picture
+                large_text = "Last match was Salmon Run on {}".format(
+                    last_match['schedule']['stage']['name'] 
+                )
+
+                # IGN and Salmon Run Rank
                 if i == 0:
-                    state = "Grade: {}".format(
-                        (last_match["grade"])["long_name"])
+                    details = "IGN: {}".format(
+                        last_match["my_result"]["name"]
+                    )
+                    state = "{} {}".format(
+                        (last_match["grade"])["long_name"],
+                        last_match["grade_point"]
+                    )
+
+                # Friend code
                 elif i == 1:
-                    state = "Friend code: {}".format(friend_code)
+                    if not friend_code:
+                        state = "FC: Not Given"
+                    else:
+                        state = "FC: {}".format(friend_code)
+
+                # Hazard Level
                 elif i == 2:
-                    state = "Difficulty: {}".format(
-                        str(last_match["danger_rate"]))
+                    state = "Hazard Level: {}".format(
+                        str(last_match["danger_rate"]) + "%"
+                    )
+
+                # Result and Total Collected Golden Eggs / Power Eggs
                 elif i == 3:
-                    state = "Played on {}".format(
-                        last_match['schedule']['stage']['name'])
+                   details = "{}".format(
+                       outcome
+                   )
+
+                   state = "{} GoldEggs / {} powEggs".format(
+                       goldEgg,
+                       powEgg
+                   )
+
+                # Save / Death Ratio
+                elif i == 4:
+                    state = "Save/Death Ratio: {}/{}".format(
+                        last_match["my_result"]["help_count"],
+                        last_match["my_result"]["dead_count"]
+                    )
+
+                if minutes_since < timeout_minutes:
+                    RPC.update(
+                        details=details,
+                        state=state, 
+                        large_image=gamemode_key, 
+                        small_image="default",
+                        large_text=large_text
+                    )
+                else:
+                    RPC.clear()
+                    logger.debug("RPC cleared, not in game long enough")
+                time.sleep(time_interval)
+
+            # When Previous Match was Turf, Ranked, League or Private
             else:
+
+                # Decides if last Match is shown in hours, minutes or seconds
+                if minutes_since >= 60:
+                    details = "Last match: {} h(s) ago".format(hours_since)
+                elif minutes_since > 1:
+                    details = "Last match: {} min(s) ago".format(
+                        math.floor(minutes_since))
+                else:
+                    details = "Last match: {} sec(s) ago".format(seconds_since)
+
+                # When hovering on the Picture
                 large_text = "Last match was {}, {} on {}".format(
-                    last_match["game_mode"]["name"], last_match["rule"]["name"], last_match["stage"]["name"])
+                    last_match["game_mode"]["name"], 
+                    last_match["rule"]["name"], 
+                    last_match["stage"]["name"]
+                )
+
+                # Gets Gamemode Key in order to change the Picture
                 gamemode_key = last_match["rule"]["key"]
+
+                # IGN and Level
                 if i == 0:
-                    state = "Friend code: {}".format(friend_code)
+                    details = "IGN: {}".format(
+                        last_match["player_result"]["player"]["nickname"]
+                    )
+
+                    if not last_match["star_rank"]:
+                        state = "Level: {}".format(
+                            last_match["player_result"]["player"]["player_rank"]
+                        )
+                    else:
+                        state = "Level: {}☆{}".format(
+                            last_match["player_result"]["player"]["player_rank"],
+                            last_match["player_result"]["player"]["star_rank"]
+                        )
+
+                # Friend Code
                 elif i == 1:
-                    state = "K/D: {}/{}".format(last_match["player_result"]["kill_count"],
-                                                last_match["player_result"]["death_count"])
+                    if not friend_code:
+                        state = "FC: Not Given"
+                    else:
+                        state = "FC: {}".format(friend_code)
+
+                # Kill (Assist) / Death Ratio
                 elif i == 2:
+                    state = "K(A)/D: {}({})/{}".format(
+                        last_match["player_result"]["kill_count"],
+                        last_match["player_result"]["assist_count"],
+                        last_match["player_result"]["death_count"]
+                    )
+
+                # Result and Percentages
+                elif i == 3:
                     details = last_match["my_team_result"]["name"]
                     try:
                         state = "{}% vs {}%".format(
-                            last_match["my_team_percentage"], last_match["other_team_percentage"])
+                            last_match["my_team_percentage"], last_match["other_team_percentage"]
+                        )
                     except KeyError:
                         try:
                             state = "{} vs {}".format(
-                                last_match["my_team_count"], last_match["other_team_count"])
+                                last_match["my_team_count"], last_match["other_team_count"]
+                            )
                         except KeyError:
                             state = "Gamemode not yet supported"
 
-                elif i == 3:
+                # Used Weapon and Total Points
+                elif i == 4:
                     state = "{}p".format(
-                        last_match["player_result"]["game_paint_point"])
+                        last_match["player_result"]["game_paint_point"]
+                    )
+
                     if show_weapon:
                         details = "{}".format(
-                            last_match["player_result"]["player"]["weapon"]["name"])
+                            last_match["player_result"]["player"]["weapon"]["name"]
+                        )
                     else:
                         pass
-            if minutes_since < timeout_minutes:
-                RPC.update(details=details, state=state, large_image=gamemode_key, small_image="default",
-                           large_text=large_text)
-            else:
-                RPC.clear()
-                logger.debug("RPC cleared, not in game long enough")
-            time.sleep(time_interval)
+                   
+                if minutes_since < timeout_minutes:
+                    RPC.update(
+                        details=details,
+                        state=state,
+                        large_image=gamemode_key,
+                        small_image="default",
+                        large_text=large_text
+                    )
+                else:
+                    RPC.clear()
+                    logger.debug("RPC cleared, not in game long enough")
+                time.sleep(time_interval)
 
 
 if __name__ == "__main__":

--- a/nso_functions.py
+++ b/nso_functions.py
@@ -103,11 +103,20 @@ class NSOInterface:
         data = self.load_json("results")
         results = data['results']
         if salmonrun:
+
+            # Assigning salmonrun_data with SR JSON
             salmonrun_data = self.load_json("coop_results")
-            for coop_match in salmonrun_data['results']:
-                for x in range(0, len(results)):
-                    pvp_match = results[x]
-                    if pvp_match['start_time'] < coop_match['start_time']:
-                        results.insert(x, coop_match)
-                        break
+
+            # Assigning coop_match with the most recent played Salmon Run Match
+            coop_match = salmonrun_data['results'][0]
+
+            for x in range(0, len(results)):
+                pvp_match = results[x]
+
+                # Checks if the last played SR match has a higher Unix Value than the last played other Match (Turf, Ranked, League, Private)
+                # If yes, insert the data of the last played Salmon Run Match in the results
+                if pvp_match['start_time'] < coop_match['start_time']:
+                    results.insert(x, coop_match)
+                    break
+            
         return results


### PR DESCRIPTION
**General**
- Cleaner Code and more Comments
- Increased the range of i from (0,4) to (0,5)
- The Last Recent Played Match/Run Time has been fixed (didn't came further than 24h)
- The Last Recent Played Match/Run Time has Day Support now

**Regular Matches / Ranked / League**
- Because of the increased range of i, the Rich Presence is able to show an extra state/detail for In-Game Name and Level
- IGN Support
- If player has a prestige, a Level star would show up with a number that indicates how many times the player's Prestiged
- The RP will show the Kill (Assist) / Death Ratio now (Was Kill/Death Ratio first)
- If the Recent Played Match was in a Ranked Lobby, the RP will show the Players Rank of that specific Played Rank Mode (X Rank/Power Supported)
- If the Recent Played Match was in a Ranked Lobby, the RP will show the League Power of it (only after 7 Played League Battles)

**Salmon Run**
- Showing now the Correct Time of Last Played Run (was showing the Last Played Match of Turf, Ranked etc. first)
- Checks how many Total Waves were played in Last Run and calculates the total collected Golden Eggs / Power Eggs
- Added Save/Death Ratio
- Shows how many points you have for your Rank

**Misc**
- A Video Tutorial is being made by me how other people can easily setup the Splatoon 2 Rich Presence with their own Account, coming soon!